### PR TITLE
feat: allows configure to consider parent folder name in queries

### DIFF
--- a/BrowserBookmarks.py
+++ b/BrowserBookmarks.py
@@ -200,7 +200,11 @@ class BrowserBookmarks(Extension):
 
         logger.debug("Finding bookmark entries for query %s" % query)
 
-        querier = BookmarkQuerier()
+        filter_by_folders = self.preferences["filter_by_folders"]
+        querier = BookmarkQuerier(
+            filter_by_folders=filter_by_folders,
+        )
+
 
         for bookmarks_path, browser in self.bookmarks_paths:
             matches: List[Dict[str, str | Dict[str, str]]] = []

--- a/BrowserBookmarks.py
+++ b/BrowserBookmarks.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Any, List, Tuple, Dict, Union
+from typing import List, Tuple, Dict, Union
 from querier import BookmarkQuerier
 
 from ulauncher.api.client.EventListener import EventListener

--- a/BrowserBookmarks.py
+++ b/BrowserBookmarks.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from typing import Any, List, Tuple, Dict, Union
+from querier import BookmarkQuerier
 
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.client.Extension import Extension
@@ -164,6 +165,7 @@ class BrowserBookmarks(Extension):
             query (str): The query
             matches (List[Dict[str, Any]]): The list to append matches to
         """
+
         if self.matches_len >= self.max_matches_len:
             return
 
@@ -198,14 +200,16 @@ class BrowserBookmarks(Extension):
 
         logger.debug("Finding bookmark entries for query %s" % query)
 
+        querier = BookmarkQuerier()
+
         for bookmarks_path, browser in self.bookmarks_paths:
             matches: List[Dict[str, str | Dict[str, str]]] = []
 
             with open(bookmarks_path) as data_file:
                 data = json.load(data_file)
-                self.find_rec(data["roots"]["bookmark_bar"], query, matches)
-                self.find_rec(data["roots"]["synced"], query, matches)
-                self.find_rec(data["roots"]["other"], query, matches)
+                querier.search(data["roots"]["bookmark_bar"], query, matches)
+                querier.search(data["roots"]["synced"], query, matches)
+                querier.search(data["roots"]["other"], query, matches)
 
             for bookmark in matches:
                 bookmark_name: bytes = str(bookmark["name"]).encode("utf-8")

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: help
+help: ## Lists the available commands. Add a comment with '##' to describe a command.
+	@grep -E '^[a-zA-Z_-].+:.*?## .*$$' $(MAKEFILE_LIST)\
+		| sort\
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run all tests
+	python -m unittest discover -s tests

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
     {
       "id": "filter_by_folders",
       "type": "select",
-      "name": "Filter by folders (yes/no)",
+      "name": "Filter by folders",
       "description": "When enabled, takes into account the folder structure of bookmarks while filtering",
       "default_value": false,
       "options": [

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,17 @@
       "name": "Additional browser paths",
       "description": "Additional paths to search for browser bookmarks, separated by a colon",
       "default_value": ""
+    },
+    {
+      "id": "filter_by_folders",
+      "type": "select",
+      "name": "Filter by folders (yes/no)",
+      "description": "When enabled, takes into account the folder structure of bookmarks while filtering",
+      "default_value": false,
+      "options": [
+          {"text": "Disabled", "value": false},
+          {"text": "Enabled", "value": true}
+      ]
     }
   ]
 }

--- a/querier/BookmarkQuerier.py
+++ b/querier/BookmarkQuerier.py
@@ -1,7 +1,13 @@
 from typing import Any, List, Dict
 
 class BookmarkQuerier:
-    def __init__(self):
+    def __init__(self, filter_by_folders: bool = False) -> None:
+        """
+        Initializes the BookmarkQuerier class.
+        Parameters:
+            filter_by_folders (bool): Whether to filter by folders
+        """
+        self.filter_by_folders = filter_by_folders
         self.matches_len = 0
         self.max_matches_len = 10
 
@@ -28,11 +34,11 @@ class BookmarkQuerier:
         else:
             sub_queries = query.split(" ")
             bookmark_title = bookmark_entry["name"]
-            bookmark_url = bookmark_entry["url"]
+            bookmark_url = bookmark_entry.get("url", "")
             
             # Create search text that includes parent folder name, bookmark name and URL
             search_text = f"{bookmark_title} {bookmark_url}"
-            if parent_name:
+            if parent_name and self.filter_by_folders:
                 search_text = f"{parent_name} {search_text}"
 
             if not self.contains_all_substrings(search_text, sub_queries):

--- a/querier/BookmarkQuerier.py
+++ b/querier/BookmarkQuerier.py
@@ -8,7 +8,6 @@ class BookmarkQuerier:
             filter_by_folders (bool): Whether to filter by folders
         """
         self.filter_by_folders = filter_by_folders
-        self.matches_len = 0
         self.max_matches_len = 10
 
     def search(
@@ -25,7 +24,7 @@ class BookmarkQuerier:
             matches (List[Dict[str, Any]]): The list to append matches to
             parent_name (str, optional): The name of the parent folder
         """
-        if self.matches_len >= self.max_matches_len:
+        if len(matches) >= self.max_matches_len:
             return
 
         if bookmark_entry["type"] == "folder":
@@ -45,7 +44,6 @@ class BookmarkQuerier:
                 return
 
             matches.append(bookmark_entry)
-            self.matches_len += 1
 
     def contains_all_substrings(self, text: str, substrings: List[str]) -> bool:
         """

--- a/querier/BookmarkQuerier.py
+++ b/querier/BookmarkQuerier.py
@@ -28,8 +28,9 @@ class BookmarkQuerier:
             return
 
         if bookmark_entry["type"] == "folder":
+            parent_tree = f"{parent_name} {bookmark_entry['name']}"
             for child_bookmark_entry in bookmark_entry["children"]:
-                self.search(child_bookmark_entry, query, matches, bookmark_entry["name"])
+                self.search(child_bookmark_entry, query, matches, parent_tree)
         else:
             sub_queries = query.split(" ")
             bookmark_title = bookmark_entry["name"]

--- a/querier/BookmarkQuerier.py
+++ b/querier/BookmarkQuerier.py
@@ -1,0 +1,58 @@
+from typing import Any, List, Dict
+
+class BookmarkQuerier:
+    def __init__(self):
+        self.matches_len = 0
+        self.max_matches_len = 10
+
+    def search(
+            self, bookmark_entry: Dict[str, Any], query: str, matches: List[Dict[str, Any]], 
+            parent_name: str = ""
+            ) -> None:
+        """
+        Recursively edits the matches variable with bookmark entries that match the query.
+        Matches if query terms are found in either name, URL, or parent folder name.
+
+        Parameters:
+            bookmark_entry (Dict[str, Any]): The bookmark entry to search
+            query (str): The query
+            matches (List[Dict[str, Any]]): The list to append matches to
+            parent_name (str, optional): The name of the parent folder
+        """
+        if self.matches_len >= self.max_matches_len:
+            return
+
+        if bookmark_entry["type"] == "folder":
+            for child_bookmark_entry in bookmark_entry["children"]:
+                self.search(child_bookmark_entry, query, matches, bookmark_entry["name"])
+        else:
+            sub_queries = query.split(" ")
+            bookmark_title = bookmark_entry["name"]
+            bookmark_url = bookmark_entry["url"]
+            
+            # Create search text that includes parent folder name, bookmark name and URL
+            search_text = f"{bookmark_title} {bookmark_url}"
+            if parent_name:
+                search_text = f"{parent_name} {search_text}"
+
+            if not self.contains_all_substrings(search_text, sub_queries):
+                return
+
+            matches.append(bookmark_entry)
+            self.matches_len += 1
+
+    def contains_all_substrings(self, text: str, substrings: List[str]) -> bool:
+        """
+        Check if all substrings are in the text
+
+        Parameters:
+            text (str): The text to match against
+            substrings (List[str]): The substrings to check
+
+        Returns:
+            bool: True if all substrings are in the text, False otherwise
+        """
+        for substring in substrings:
+            if substring.lower() not in text.lower():
+                return False
+        return True

--- a/querier/__init__.py
+++ b/querier/__init__.py
@@ -1,0 +1,1 @@
+from .BookmarkQuerier import BookmarkQuerier

--- a/querier/__init__.py
+++ b/querier/__init__.py
@@ -1,1 +1,1 @@
-from .BookmarkQuerier import BookmarkQuerier
+from .BookmarkQuerier import BookmarkQuerier as BookmarkQuerier

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,17 @@
+import unittest
+import sys
+import os
+
+# Add the current directory to the Python path
+sys.path.append(os.path.abspath('.'))
+
+if __name__ == '__main__':
+    # Discover and run all tests in the tests directory
+    test_loader = unittest.TestLoader()
+    test_suite = test_loader.discover('tests', pattern='test_*.py')
+    
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(test_suite)
+    
+    # Exit with non-zero code if tests failed
+    sys.exit(not result.wasSuccessful()) 

--- a/tests/test_bookmark_querier.py
+++ b/tests/test_bookmark_querier.py
@@ -1,208 +1,185 @@
 import unittest
 from querier import BookmarkQuerier
 
+bookmarks = {
+    "type": "folder",
+    "name": "root",
+    "children": [
+        {
+            "type": "bookmark",
+            "name": "git tutorial",
+            "url": "https://git.org"
+        },
+        {
+            "type": "folder",
+            "name": "Python",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": "Documentation",
+                    "url": "https://docs.python.org"
+                },
+                {
+                    "type": "bookmark",
+                    "name": "Python Tutorial",
+                    "url": "https://learn.python.org"
+                },
+                {
+                    "type": "folder",
+                    "name": "Advanced",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "Documentation and Tutorial - python",
+                            "url": "https://documentation.python.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Python Tricks Tutorial",
+                            "url": "https://realpython.com"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Zen of Python",
+                            "url": "https://peps.python.org/pep-0020/"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "folder",
+            "name": "Typescript",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": "Documentation",
+                    "url": "https://docs.typescript.org"
+                },
+                {
+                    "type": "bookmark",
+                    "name": "Typescript Tutorial",
+                    "url": "https://learn.typescript.org"
+                },
+                {
+                    "type": "folder",
+                    "name": "Advanced",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "Documentation and Tutorial",
+                            "url": "https://documentation.typescript.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Typescript Tricks Tutorial",
+                            "url": "https://typescript.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Zen of Typescript",
+                            "url": "https://notfound.com"
+                        }
+                    ]
+                }
+
+            ]
+        }
+    ]
+}
 class TestBookmarkQuerierNoFilterByFolders(unittest.TestCase):
     def setUp(self):
         self.querier = BookmarkQuerier()
 
-    def test_by_default_does_not_filter_by_folders(self):
-        test_bookmarks = {
-            "type": "folder",
-            "name": "root",
-            "children": [
-                {
-                    "type": "bookmark",
-                    "name": "Google Search",
-                    "url": "https://google.com"
-                },
-                {
-                    "type": "bookmark",
-                    "name": "Google profile",
-                    "url": "https://me.google.com"
-                },
-                {
-                    "type": "folder",
-                    "name": "Social Media",
-                    "children": [
-                        {
-                            "type": "bookmark",
-                            "name": "GitHub Profile",
-                            "url": "https://github.com"
-                        },
-                        {
-                            "type": "bookmark",
-                            "name": "LinkedIn profile",
-                            "url": "https://linkedin.com"
-                        }
+    def test_matches_any_bookmark_that_contains_query_words(self):
+        matches = []
+        self.querier.search(bookmarks, "documentation", matches)
+        self.assertEqual(len(matches), 4)
+        self.assertEqual(matches[0]["name"], "Documentation")
+        self.assertEqual(matches[0]["url"], "https://docs.python.org")
+        self.assertEqual(matches[1]["name"], "Documentation and Tutorial - python")
+        self.assertEqual(matches[1]["url"], "https://documentation.python.org")
+        self.assertEqual(matches[2]["name"], "Documentation")
+        self.assertEqual(matches[2]["url"], "https://docs.typescript.org")
+        self.assertEqual(matches[3]["name"], "Documentation and Tutorial")
+        self.assertEqual(matches[3]["url"], "https://documentation.typescript.org")
+
+        matches = []
+        self.querier.search(bookmarks, "documentation tutorial", matches)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(matches[0]["name"], "Documentation and Tutorial - python")
+        self.assertEqual(matches[0]["url"], "https://documentation.python.org")
+        self.assertEqual(matches[1]["name"], "Documentation and Tutorial")
+        self.assertEqual(matches[1]["url"], "https://documentation.typescript.org")
+
+        matches = []
+        self.querier.search(bookmarks, "tutorial", matches)
+        self.assertEqual(len(matches), 7)
+        self.assertEqual(matches[0]["name"], "git tutorial")
+        self.assertEqual(matches[1]["name"], "Python Tutorial")
+
+
+    def test_doesnot_filter_by_folders(self):
+        matches = []
+        self.querier.search(bookmarks, "advanced documentation", matches)
+        self.assertEqual(len(matches), 0)
+
+        matches = []
+        self.querier.search(bookmarks, "python advanced", matches)
+        self.assertEqual(len(matches), 0)
+
+        matches = []
+        self.querier.search(bookmarks, "advanced tutorial", matches)
+        self.assertEqual(len(matches), 0)
+
+    def test_query_max_matches(self):
+        # Create a bookmark structure with many entries
+        many_bookmarks = {
+                "type": "folder",
+                "name": "root",
+                "children": [
+                    {
+                        "type": "bookmark",
+                        "name": f"Test {i}",
+                        "url": f"https://test{i}.com"
+                        } for i in range(15)
                     ]
                 }
-            ]
-        }
 
         matches = []
-        self.querier.search(test_bookmarks, "google", matches)
-        self.assertEqual(len(matches), 2)
-        self.assertEqual(matches[0]["name"], "Google Search")
-        self.assertEqual(matches[1]["name"], "Google profile")
-
-        matches = []
-        self.querier.search(test_bookmarks, "profile", matches)
-        self.assertEqual(len(matches), 3)
-
-        matches = []
-        self.querier.search(test_bookmarks, "google profile", matches)
-        self.assertEqual(len(matches), 1)
-    
+        self.querier.search(many_bookmarks, "Test", matches)
+        self.assertEqual(len(matches), 10)  # Should stop at max_matches_len 
 
 class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
     def setUp(self):
-        # Sample bookmark structure for testing
-        self.test_bookmarks = {
-            "type": "folder",
-            "name": "root",
-            "children": [
-                {
-                    "type": "bookmark",
-                    "name": "Google Search",
-                    "url": "https://google.com"
-                },
-                {
-                    "type": "folder",
-                    "name": "Social Media",
-                    "children": [
-                        {
-                            "type": "bookmark",
-                            "name": "GitHub Profile",
-                            "url": "https://github.com"
-                        },
-                        {
-                            "type": "bookmark",
-                            "name": "LinkedIn Page",
-                            "url": "https://linkedin.com"
-                        }
+        self.querier = BookmarkQuerier(filter_by_folders=True)
 
-                    ]
-                }
-            ]
-        }
-
-        self.complex_tree_bookmark = {
-            "type": "folder",
-            "name": "root",
-            "children": [
-                {
-                    "type": "bookmark",
-                    "name": "git tutorial",
-                    "url": "https://git.org"
-                },
-                {
-                    "type": "folder",
-                    "name": "Python",
-                    "children": [
-                        {
-                            "type": "bookmark",
-                            "name": "Documentation",
-                            "url": "https://docs.python.org"
-                        },
-                        {
-                            "type": "bookmark",
-                            "name": "Python Tutorial",
-                            "url": "https://learn.python.org"
-                        },
-                        # Test subfolder
-                        {
-                            "type": "folder",
-                            "name": "Advanced",
-                            "children": [
-                                {
-                                    "type": "bookmark",
-                                    "name": "Documentation and Tutorial",
-                                    "url": "https://documentation.typescript.org"
-                                },
-                                {
-                                    "type": "bookmark",
-                                    "name": "Python Tricks Tutorial",
-                                    "url": "https://realpython.com"
-                                },
-                                {
-                                    "type": "bookmark",
-                                    "name": "Zen of Python",
-                                    "url": "https://peps.python.org/pep-0020/"
-                                }
-                            ]
-                        }
-
-                    ]
-                },
-                {
-                    "type": "folder",
-                    "name": "Typescript",
-                    "children": [
-                        {
-                            "type": "bookmark",
-                            "name": "Documentation",
-                            "url": "https://docs.typescript.org"
-                        },
-                        {
-                            "type": "bookmark",
-                            "name": "Typescript Tutorial",
-                            "url": "https://learn.typescript.org"
-                        },
-                        # Test subfolder
-                        {
-                            "type": "folder",
-                            "name": "Advanced",
-                            "children": [
-                                {
-                                    "type": "bookmark",
-                                    "name": "Documentation and Tutorial",
-                                    "url": "https://documentation.typescript.org"
-                                },
-                                {
-                                    "type": "bookmark",
-                                    "name": "Typescript Tricks Tutorial",
-                                    "url": "https://typescript.org"
-                                },
-                                {
-                                    "type": "bookmark",
-                                    "name": "Zen of Typescript",
-                                    "url": "https://notfound.com"
-                                }
-                            ]
-                        }
-
-                    ]
-                }
-            ]
-        }
-        
-        self.querier = BookmarkQuerier(
-            filter_by_folders=True
-        )
-
-    def test_contains_all_substrings(self):
-        # Test basic substring matching
-        self.assertTrue(self.querier.contains_all_substrings("Hello World", ["hello", "world"]))
-        self.assertTrue(self.querier.contains_all_substrings("Hello World", ["HeLLo", "WORLD"]))
-        self.assertFalse(self.querier.contains_all_substrings("Hello World", ["hello", "python"]))
-        self.assertTrue(self.querier.contains_all_substrings("Hello World", []))
-
-    def test_query_single_word(self):
+    def test_matches_any_bookmark_that_contains_query_words(self):
         matches = []
-        self.querier.search(self.test_bookmarks, "github", matches)
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0]["name"], "GitHub Profile")
+        self.querier.search(bookmarks, "documentation", matches)
+        self.assertEqual(len(matches), 4)
+        self.assertEqual(matches[0]["name"], "Documentation")
+        self.assertEqual(matches[0]["url"], "https://docs.python.org")
+        self.assertEqual(matches[1]["name"], "Documentation and Tutorial - python")
+        self.assertEqual(matches[1]["url"], "https://documentation.python.org")
+        self.assertEqual(matches[2]["name"], "Documentation")
+        self.assertEqual(matches[2]["url"], "https://docs.typescript.org")
+        self.assertEqual(matches[3]["name"], "Documentation and Tutorial")
+        self.assertEqual(matches[3]["url"], "https://documentation.typescript.org")
 
-    def test_query_multiple_words(self):
         matches = []
-        self.querier.search(self.test_bookmarks, "github profile", matches)
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0]["name"], "GitHub Profile")
+        self.querier.search(bookmarks, "documentation tutorial", matches)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(matches[0]["name"], "Documentation and Tutorial - python")
+        self.assertEqual(matches[0]["url"], "https://documentation.python.org")
+        self.assertEqual(matches[1]["name"], "Documentation and Tutorial")
+        self.assertEqual(matches[1]["url"], "https://documentation.typescript.org")
 
-    def test_query_no_matches(self):
         matches = []
-        self.querier.search(self.test_bookmarks, "nonexistent", matches)
-        self.assertEqual(len(matches), 0)
+        self.querier.search(bookmarks, "tutorial", matches)
+        self.assertEqual(len(matches), 7)
+        self.assertEqual(matches[0]["name"], "git tutorial")
+        self.assertEqual(matches[1]["name"], "Python Tutorial")
 
     def test_query_max_matches(self):
         # Create a bookmark structure with many entries
@@ -217,74 +194,57 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
                 } for i in range(15)
             ]
         }
-        
+
         matches = []
         self.querier.search(many_bookmarks, "Test", matches)
         self.assertEqual(len(matches), 10)  # Should stop at max_matches_len 
-
+    
     def test_search_matches_parent_folder(self):
         matches = []
-        self.querier.search(self.complex_tree_bookmark, "python documentation", matches)
-        self.assertEqual(len(matches), 1)
+        self.querier.search(bookmarks, "python documentation", matches)
+        self.assertEqual(len(matches), 2)
         self.assertEqual(matches[0]["name"], "Documentation")
         self.assertEqual(matches[0]["url"], "https://docs.python.org")
+        self.assertEqual(matches[1]["name"], "Documentation and Tutorial - python")
+        self.assertEqual(matches[1]["url"], "https://documentation.python.org")
 
         # Make sure to consider URL matches as well
         matches = []
-        self.querier.search(self.complex_tree_bookmark, "python learn", matches)
+        self.querier.search(bookmarks, "python learn", matches)
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Python Tutorial")
         self.assertEqual(matches[0]["url"], "https://learn.python.org")
-
-    def test_filter_by_bookmark_name_independent_of_parent(self):
-        # Test that it still works with just the bookmark name
+    
+    def test_filter_by_parent_tree(self):
+        # Sanity check
         matches = []
-        self.querier.search(self.complex_tree_bookmark, "documentation", matches)
-        self.assertEqual(len(matches), 4)
-        # Matches python documentation
-        self.assertEqual(matches[0]["name"], "Documentation")
-        self.assertEqual(matches[0]["url"], "https://docs.python.org")
-        # Matches typescript documentation
-        self.assertEqual(matches[1]["name"], "Documentation")
-        self.assertEqual(matches[1]["url"], "https://docs.typescript.org")
-        
-
-    def test_filter_multiple_folders_name(self):
-        # Test that it still works with just the bookmark name
-        # Test that it matches folder and subfolder
-        matches = []
-        self.querier.search(self.complex_tree_bookmark, "python advanced", matches)
-        self.assertEqual(len(matches), 2)
-        matches = []
-        self.querier.search(self.complex_tree_bookmark, "typescript advanced", matches)
-        self.assertEqual(len(matches), 2)
-
-    def test_filter_by_bookmark_name_only(self):
-        matches = []
-        self.querier.search(self.complex_tree_bookmark, "tutorial", matches)
-        self.assertEqual(len(matches), 7)
-        self.assertEqual(matches[0]["name"], "git tutorial")
-        self.assertEqual(matches[1]["name"], "Python Tutorial")
-        self.assertEqual(matches[2]["name"], "Python Tricks Tutorial")
-        self.assertEqual(matches[3]["name"], "Typescript Tutorial")
+        self.querier.search(bookmarks, "advanced", matches)
+        self.assertEqual(len(matches), 6)
 
         matches = []
-        self.querier.search(self.complex_tree_bookmark, "advanced tutorial", matches)
-        self.assertEqual(len(matches), 2)
-        self.assertEqual(matches[0]["name"], "Python Tricks Tutorial")
-
-    def test_matches_children_and_grand_children(self):
+        self.querier.search(bookmarks, "python advanced", matches)
+        self.assertEqual(len(matches), 3)
+        matches = []
+        self.querier.search(bookmarks, "typescript advanced", matches)
+        self.assertEqual(len(matches), 3)
+    
+    def test_filter_by_children_and_grand_children(self):
         # Test that it matches when both parent and bookmark match
         # Should match: python/* && python/Advanced/*
         matches = []
-        self.querier.search(self.complex_tree_bookmark, "python tutorial", matches)
-        self.assertEqual(len(matches), 2)
+        self.querier.search(bookmarks, "python tutorial", matches)
+        self.assertEqual(len(matches), 3)
         self.assertEqual(matches[0]["name"], "Python Tutorial")
-        self.assertEqual(matches[1]["name"], "Python Tricks Tutorial")
-        
-    def test_filter_by_bookmark_name_and_parent_no_match(self):
+        self.assertEqual(matches[0]["url"], "https://learn.python.org")
+        self.assertEqual(matches[1]["name"], "Documentation and Tutorial - python")
+        self.assertEqual(matches[1]["url"], "https://documentation.python.org")
+        self.assertEqual(matches[2]["name"], "Python Tricks Tutorial")
+        self.assertEqual(matches[2]["url"], "https://realpython.com")
+
+    def test_filter_by_bookmark_name_and_parent_dont_match(self):
         # Test that it doesn't match when neither parent nor bookmark match
         matches = []
-        self.querier.search(self.complex_tree_bookmark, "java docs", matches)
+        self.querier.search(bookmarks, "java", matches)
         self.assertEqual(len(matches), 0) 
-
+        self.querier.search(bookmarks, "java docs", matches)
+        self.assertEqual(len(matches), 0) 

--- a/tests/test_bookmark_querier.py
+++ b/tests/test_bookmark_querier.py
@@ -80,6 +80,7 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
                             "name": "LinkedIn Page",
                             "url": "https://linkedin.com"
                         }
+
                     ]
                 }
             ]
@@ -163,6 +164,45 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
                                     "type": "bookmark",
                                     "name": "Python Tricks Tutorial",
                                     "url": "https://realpython.com"
+                                },
+                                {
+                                    "type": "bookmark",
+                                    "name": "Zen of Python",
+                                    "url": "https://peps.python.org/pep-0020/"
+                                }
+                            ]
+                        }
+
+                    ]
+                },
+                {
+                    "type": "folder",
+                    "name": "Typescript",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "Documentation",
+                            "url": "https://docs.typescript.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Typescript Tutorial",
+                            "url": "https://learn.typescript.org"
+                        },
+                        # Test subfolder
+                        {
+                            "type": "folder",
+                            "name": "Advanced",
+                            "children": [
+                                {
+                                    "type": "bookmark",
+                                    "name": "Typescript Tricks Tutorial",
+                                    "url": "https://typescript.org"
+                                },
+                                {
+                                    "type": "bookmark",
+                                    "name": "Zen of Typescript",
+                                    "url": "https://notfound.com"
                                 }
                             ]
                         }
@@ -174,7 +214,6 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
         
         matches = []
         self.querier.search(bookmarks, "python documentation", matches)
-        
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Documentation")
         self.assertEqual(matches[0]["url"], "https://docs.python.org")
@@ -190,21 +229,28 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
         # Test that it still works with just the bookmark name
         matches = []
         self.querier.search(bookmarks, "documentation", matches)
-        self.assertEqual(len(matches), 1)
+        self.assertEqual(len(matches), 2)
+        # Matches python documentation
+        self.assertEqual(matches[0]["name"], "Documentation")
+        self.assertEqual(matches[0]["url"], "https://docs.python.org")
+        # Matches typescript documentation
+        self.assertEqual(matches[1]["name"], "Documentation")
+        self.assertEqual(matches[1]["url"], "https://docs.typescript.org")
+        
 
         # Test that it matches folder and subfolder
         matches = []
         self.querier.search(bookmarks, "python advanced", matches)
-        self.assertEqual(len(matches), 1)
+        self.assertEqual(len(matches), 2)
 
         matches = []
         self.querier.search(bookmarks, "tutorial", matches)
-        self.assertEqual(len(matches), 3)
+        self.assertEqual(len(matches), 5)
         self.assertEqual(matches[0]["name"], "git tutorial")
 
         matches = []
         self.querier.search(bookmarks, "advanced tutorial", matches)
-        self.assertEqual(len(matches), 1)
+        self.assertEqual(len(matches), 2)
         self.assertEqual(matches[0]["name"], "Python Tricks Tutorial")
 
         # Test that it matches when both parent and bookmark match

--- a/tests/test_bookmark_querier.py
+++ b/tests/test_bookmark_querier.py
@@ -3,11 +3,9 @@ from querier import BookmarkQuerier
 
 class TestBookmarkQuerierNoFilterByFolders(unittest.TestCase):
     def setUp(self):
-        self.querier = BookmarkQuerier(
-            filter_by_folders=False
-        )
+        self.querier = BookmarkQuerier()
 
-    def test_contains_all_substrings(self):
+    def test_by_default_does_not_filter_by_folders(self):
         test_bookmarks = {
             "type": "folder",
             "name": "root",
@@ -128,11 +126,8 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
             ]
         }
         
-        querier = BookmarkQuerier(
-            filter_by_folders=True
-        )
         matches = []
-        querier.search(many_bookmarks, "Test", matches)
+        self.querier.search(many_bookmarks, "Test", matches)
         self.assertEqual(len(matches), 10)  # Should stop at max_matches_len 
 
     def test_search_matches_parent_folder(self):
@@ -177,11 +172,8 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
             ]
         }
         
-        querier = BookmarkQuerier(
-            filter_by_folders=True
-        )
         matches = []
-        querier.search(bookmarks, "python documentation", matches)
+        self.querier.search(bookmarks, "python documentation", matches)
         
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Documentation")
@@ -189,7 +181,7 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
 
         # Make sure to consider URL matches as well
         matches = []
-        querier.search(bookmarks, "python learn", matches)
+        self.querier.search(bookmarks, "python learn", matches)
         
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Python Tutorial")
@@ -197,34 +189,34 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
 
         # Test that it still works with just the bookmark name
         matches = []
-        querier.search(bookmarks, "documentation", matches)
+        self.querier.search(bookmarks, "documentation", matches)
         self.assertEqual(len(matches), 1)
 
         # Test that it matches folder and subfolder
         matches = []
-        querier.search(bookmarks, "python advanced", matches)
+        self.querier.search(bookmarks, "python advanced", matches)
         self.assertEqual(len(matches), 1)
 
         matches = []
-        querier.search(bookmarks, "tutorial", matches)
+        self.querier.search(bookmarks, "tutorial", matches)
         self.assertEqual(len(matches), 3)
         self.assertEqual(matches[0]["name"], "git tutorial")
 
         matches = []
-        querier.search(bookmarks, "advanced tutorial", matches)
+        self.querier.search(bookmarks, "advanced tutorial", matches)
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Python Tricks Tutorial")
 
         # Test that it matches when both parent and bookmark match
         # Should match: python/* && python/Advanced/*
         matches = []
-        querier.search(bookmarks, "python tutorial", matches)
+        self.querier.search(bookmarks, "python tutorial", matches)
         self.assertEqual(len(matches), 2)
         self.assertEqual(matches[0]["name"], "Python Tutorial")
         self.assertEqual(matches[1]["name"], "Python Tricks Tutorial")
         
         # Test that it doesn't match when neither parent nor bookmark match
         matches = []
-        querier.search(bookmarks, "java docs", matches)
+        self.querier.search(bookmarks, "java docs", matches)
         self.assertEqual(len(matches), 0) 
 

--- a/tests/test_bookmark_querier.py
+++ b/tests/test_bookmark_querier.py
@@ -1,7 +1,62 @@
 import unittest
 from querier import BookmarkQuerier
 
-class TestBookmarkQuerier(unittest.TestCase):
+class TestBookmarkQuerierNoFilterByFolders(unittest.TestCase):
+    def setUp(self):
+        self.querier = BookmarkQuerier(
+            filter_by_folders=False
+        )
+
+    def test_contains_all_substrings(self):
+        test_bookmarks = {
+            "type": "folder",
+            "name": "root",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": "Google Search",
+                    "url": "https://google.com"
+                },
+                {
+                    "type": "bookmark",
+                    "name": "Google profile",
+                    "url": "https://me.google.com"
+                },
+                {
+                    "type": "folder",
+                    "name": "Social Media",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "GitHub Profile",
+                            "url": "https://github.com"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "LinkedIn profile",
+                            "url": "https://linkedin.com"
+                        }
+                    ]
+                }
+            ]
+        }
+
+        matches = []
+        self.querier.search(test_bookmarks, "google", matches)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(matches[0]["name"], "Google Search")
+        self.assertEqual(matches[1]["name"], "Google profile")
+
+        matches = []
+        self.querier.search(test_bookmarks, "profile", matches)
+        self.assertEqual(len(matches), 3)
+
+        matches = []
+        self.querier.search(test_bookmarks, "google profile", matches)
+        self.assertEqual(len(matches), 1)
+    
+
+class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
     def setUp(self):
         # Sample bookmark structure for testing
         self.test_bookmarks = {
@@ -31,7 +86,9 @@ class TestBookmarkQuerier(unittest.TestCase):
                 }
             ]
         }
-        self.querier = BookmarkQuerier()
+        self.querier = BookmarkQuerier(
+            filter_by_folders=True
+        )
 
     def test_contains_all_substrings(self):
         # Test basic substring matching
@@ -71,7 +128,9 @@ class TestBookmarkQuerier(unittest.TestCase):
             ]
         }
         
-        querier = BookmarkQuerier()
+        querier = BookmarkQuerier(
+            filter_by_folders=True
+        )
         matches = []
         querier.search(many_bookmarks, "Test", matches)
         self.assertEqual(len(matches), 10)  # Should stop at max_matches_len 
@@ -118,7 +177,9 @@ class TestBookmarkQuerier(unittest.TestCase):
             ]
         }
         
-        querier = BookmarkQuerier()
+        querier = BookmarkQuerier(
+            filter_by_folders=True
+        )
         matches = []
         querier.search(bookmarks, "python documentation", matches)
         
@@ -166,3 +227,4 @@ class TestBookmarkQuerier(unittest.TestCase):
         matches = []
         querier.search(bookmarks, "java docs", matches)
         self.assertEqual(len(matches), 0) 
+

--- a/tests/test_bookmark_querier.py
+++ b/tests/test_bookmark_querier.py
@@ -85,6 +85,97 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
                 }
             ]
         }
+
+        self.complex_tree_bookmark = {
+            "type": "folder",
+            "name": "root",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": "git tutorial",
+                    "url": "https://git.org"
+                },
+                {
+                    "type": "folder",
+                    "name": "Python",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "Documentation",
+                            "url": "https://docs.python.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Python Tutorial",
+                            "url": "https://learn.python.org"
+                        },
+                        # Test subfolder
+                        {
+                            "type": "folder",
+                            "name": "Advanced",
+                            "children": [
+                                {
+                                    "type": "bookmark",
+                                    "name": "Documentation and Tutorial",
+                                    "url": "https://documentation.typescript.org"
+                                },
+                                {
+                                    "type": "bookmark",
+                                    "name": "Python Tricks Tutorial",
+                                    "url": "https://realpython.com"
+                                },
+                                {
+                                    "type": "bookmark",
+                                    "name": "Zen of Python",
+                                    "url": "https://peps.python.org/pep-0020/"
+                                }
+                            ]
+                        }
+
+                    ]
+                },
+                {
+                    "type": "folder",
+                    "name": "Typescript",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "Documentation",
+                            "url": "https://docs.typescript.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Typescript Tutorial",
+                            "url": "https://learn.typescript.org"
+                        },
+                        # Test subfolder
+                        {
+                            "type": "folder",
+                            "name": "Advanced",
+                            "children": [
+                                {
+                                    "type": "bookmark",
+                                    "name": "Documentation and Tutorial",
+                                    "url": "https://documentation.typescript.org"
+                                },
+                                {
+                                    "type": "bookmark",
+                                    "name": "Typescript Tricks Tutorial",
+                                    "url": "https://typescript.org"
+                                },
+                                {
+                                    "type": "bookmark",
+                                    "name": "Zen of Typescript",
+                                    "url": "https://notfound.com"
+                                }
+                            ]
+                        }
+
+                    ]
+                }
+            ]
+        }
+        
         self.querier = BookmarkQuerier(
             filter_by_folders=True
         )
@@ -132,104 +223,24 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
         self.assertEqual(len(matches), 10)  # Should stop at max_matches_len 
 
     def test_search_matches_parent_folder(self):
-        bookmarks = {
-            "type": "folder",
-            "name": "root",
-            "children": [
-                {
-                    "type": "bookmark",
-                    "name": "git tutorial",
-                    "url": "https://git.org"
-                },
-                {
-                    "type": "folder",
-                    "name": "Python",
-                    "children": [
-                        {
-                            "type": "bookmark",
-                            "name": "Documentation",
-                            "url": "https://docs.python.org"
-                        },
-                        {
-                            "type": "bookmark",
-                            "name": "Python Tutorial",
-                            "url": "https://learn.python.org"
-                        },
-                        # Test subfolder
-                        {
-                            "type": "folder",
-                            "name": "Advanced",
-                            "children": [
-                                {
-                                    "type": "bookmark",
-                                    "name": "Python Tricks Tutorial",
-                                    "url": "https://realpython.com"
-                                },
-                                {
-                                    "type": "bookmark",
-                                    "name": "Zen of Python",
-                                    "url": "https://peps.python.org/pep-0020/"
-                                }
-                            ]
-                        }
-
-                    ]
-                },
-                {
-                    "type": "folder",
-                    "name": "Typescript",
-                    "children": [
-                        {
-                            "type": "bookmark",
-                            "name": "Documentation",
-                            "url": "https://docs.typescript.org"
-                        },
-                        {
-                            "type": "bookmark",
-                            "name": "Typescript Tutorial",
-                            "url": "https://learn.typescript.org"
-                        },
-                        # Test subfolder
-                        {
-                            "type": "folder",
-                            "name": "Advanced",
-                            "children": [
-                                {
-                                    "type": "bookmark",
-                                    "name": "Typescript Tricks Tutorial",
-                                    "url": "https://typescript.org"
-                                },
-                                {
-                                    "type": "bookmark",
-                                    "name": "Zen of Typescript",
-                                    "url": "https://notfound.com"
-                                }
-                            ]
-                        }
-
-                    ]
-                }
-            ]
-        }
-        
         matches = []
-        self.querier.search(bookmarks, "python documentation", matches)
+        self.querier.search(self.complex_tree_bookmark, "python documentation", matches)
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Documentation")
         self.assertEqual(matches[0]["url"], "https://docs.python.org")
 
         # Make sure to consider URL matches as well
         matches = []
-        self.querier.search(bookmarks, "python learn", matches)
-        
+        self.querier.search(self.complex_tree_bookmark, "python learn", matches)
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0]["name"], "Python Tutorial")
         self.assertEqual(matches[0]["url"], "https://learn.python.org")
 
+    def test_filter_by_bookmark_name_independent_of_parent(self):
         # Test that it still works with just the bookmark name
         matches = []
-        self.querier.search(bookmarks, "documentation", matches)
-        self.assertEqual(len(matches), 2)
+        self.querier.search(self.complex_tree_bookmark, "documentation", matches)
+        self.assertEqual(len(matches), 4)
         # Matches python documentation
         self.assertEqual(matches[0]["name"], "Documentation")
         self.assertEqual(matches[0]["url"], "https://docs.python.org")
@@ -238,31 +249,42 @@ class TestBookmarkQuerierFilterByFolders(unittest.TestCase):
         self.assertEqual(matches[1]["url"], "https://docs.typescript.org")
         
 
+    def test_filter_multiple_folders_name(self):
+        # Test that it still works with just the bookmark name
         # Test that it matches folder and subfolder
         matches = []
-        self.querier.search(bookmarks, "python advanced", matches)
+        self.querier.search(self.complex_tree_bookmark, "python advanced", matches)
+        self.assertEqual(len(matches), 2)
+        matches = []
+        self.querier.search(self.complex_tree_bookmark, "typescript advanced", matches)
         self.assertEqual(len(matches), 2)
 
+    def test_filter_by_bookmark_name_only(self):
         matches = []
-        self.querier.search(bookmarks, "tutorial", matches)
-        self.assertEqual(len(matches), 5)
+        self.querier.search(self.complex_tree_bookmark, "tutorial", matches)
+        self.assertEqual(len(matches), 7)
         self.assertEqual(matches[0]["name"], "git tutorial")
+        self.assertEqual(matches[1]["name"], "Python Tutorial")
+        self.assertEqual(matches[2]["name"], "Python Tricks Tutorial")
+        self.assertEqual(matches[3]["name"], "Typescript Tutorial")
 
         matches = []
-        self.querier.search(bookmarks, "advanced tutorial", matches)
+        self.querier.search(self.complex_tree_bookmark, "advanced tutorial", matches)
         self.assertEqual(len(matches), 2)
         self.assertEqual(matches[0]["name"], "Python Tricks Tutorial")
 
+    def test_matches_children_and_grand_children(self):
         # Test that it matches when both parent and bookmark match
         # Should match: python/* && python/Advanced/*
         matches = []
-        self.querier.search(bookmarks, "python tutorial", matches)
+        self.querier.search(self.complex_tree_bookmark, "python tutorial", matches)
         self.assertEqual(len(matches), 2)
         self.assertEqual(matches[0]["name"], "Python Tutorial")
         self.assertEqual(matches[1]["name"], "Python Tricks Tutorial")
         
+    def test_filter_by_bookmark_name_and_parent_no_match(self):
         # Test that it doesn't match when neither parent nor bookmark match
         matches = []
-        self.querier.search(bookmarks, "java docs", matches)
+        self.querier.search(self.complex_tree_bookmark, "java docs", matches)
         self.assertEqual(len(matches), 0) 
 

--- a/tests/test_bookmark_querier.py
+++ b/tests/test_bookmark_querier.py
@@ -1,0 +1,168 @@
+import unittest
+from querier import BookmarkQuerier
+
+class TestBookmarkQuerier(unittest.TestCase):
+    def setUp(self):
+        # Sample bookmark structure for testing
+        self.test_bookmarks = {
+            "type": "folder",
+            "name": "root",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": "Google Search",
+                    "url": "https://google.com"
+                },
+                {
+                    "type": "folder",
+                    "name": "Social Media",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "GitHub Profile",
+                            "url": "https://github.com"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "LinkedIn Page",
+                            "url": "https://linkedin.com"
+                        }
+                    ]
+                }
+            ]
+        }
+        self.querier = BookmarkQuerier()
+
+    def test_contains_all_substrings(self):
+        # Test basic substring matching
+        self.assertTrue(self.querier.contains_all_substrings("Hello World", ["hello", "world"]))
+        self.assertTrue(self.querier.contains_all_substrings("Hello World", ["HeLLo", "WORLD"]))
+        self.assertFalse(self.querier.contains_all_substrings("Hello World", ["hello", "python"]))
+        self.assertTrue(self.querier.contains_all_substrings("Hello World", []))
+
+    def test_query_single_word(self):
+        matches = []
+        self.querier.search(self.test_bookmarks, "github", matches)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["name"], "GitHub Profile")
+
+    def test_query_multiple_words(self):
+        matches = []
+        self.querier.search(self.test_bookmarks, "github profile", matches)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["name"], "GitHub Profile")
+
+    def test_query_no_matches(self):
+        matches = []
+        self.querier.search(self.test_bookmarks, "nonexistent", matches)
+        self.assertEqual(len(matches), 0)
+
+    def test_query_max_matches(self):
+        # Create a bookmark structure with many entries
+        many_bookmarks = {
+            "type": "folder",
+            "name": "root",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": f"Test {i}",
+                    "url": f"https://test{i}.com"
+                } for i in range(15)
+            ]
+        }
+        
+        querier = BookmarkQuerier()
+        matches = []
+        querier.search(many_bookmarks, "Test", matches)
+        self.assertEqual(len(matches), 10)  # Should stop at max_matches_len 
+
+    def test_search_matches_parent_folder(self):
+        bookmarks = {
+            "type": "folder",
+            "name": "root",
+            "children": [
+                {
+                    "type": "bookmark",
+                    "name": "git tutorial",
+                    "url": "https://git.org"
+                },
+                {
+                    "type": "folder",
+                    "name": "Python",
+                    "children": [
+                        {
+                            "type": "bookmark",
+                            "name": "Documentation",
+                            "url": "https://docs.python.org"
+                        },
+                        {
+                            "type": "bookmark",
+                            "name": "Python Tutorial",
+                            "url": "https://learn.python.org"
+                        },
+                        # Test subfolder
+                        {
+                            "type": "folder",
+                            "name": "Advanced",
+                            "children": [
+                                {
+                                    "type": "bookmark",
+                                    "name": "Python Tricks Tutorial",
+                                    "url": "https://realpython.com"
+                                }
+                            ]
+                        }
+
+                    ]
+                }
+            ]
+        }
+        
+        querier = BookmarkQuerier()
+        matches = []
+        querier.search(bookmarks, "python documentation", matches)
+        
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["name"], "Documentation")
+        self.assertEqual(matches[0]["url"], "https://docs.python.org")
+
+        # Make sure to consider URL matches as well
+        matches = []
+        querier.search(bookmarks, "python learn", matches)
+        
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["name"], "Python Tutorial")
+        self.assertEqual(matches[0]["url"], "https://learn.python.org")
+
+        # Test that it still works with just the bookmark name
+        matches = []
+        querier.search(bookmarks, "documentation", matches)
+        self.assertEqual(len(matches), 1)
+
+        # Test that it matches folder and subfolder
+        matches = []
+        querier.search(bookmarks, "python advanced", matches)
+        self.assertEqual(len(matches), 1)
+
+        matches = []
+        querier.search(bookmarks, "tutorial", matches)
+        self.assertEqual(len(matches), 3)
+        self.assertEqual(matches[0]["name"], "git tutorial")
+
+        matches = []
+        querier.search(bookmarks, "advanced tutorial", matches)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["name"], "Python Tricks Tutorial")
+
+        # Test that it matches when both parent and bookmark match
+        # Should match: python/* && python/Advanced/*
+        matches = []
+        querier.search(bookmarks, "python tutorial", matches)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(matches[0]["name"], "Python Tutorial")
+        self.assertEqual(matches[1]["name"], "Python Tricks Tutorial")
+        
+        # Test that it doesn't match when neither parent nor bookmark match
+        matches = []
+        querier.search(bookmarks, "java docs", matches)
+        self.assertEqual(len(matches), 0) 


### PR DESCRIPTION
Hello there :wave: 

I took the liberty to implement a feature that was missing when filtering bookmarks. Usually I organize my bookmarks in folders like `projects`, `tools`, etc  and when querying the bookmarks I had to query by their exact name. I wanted to filter them but "pre filtered" by the parent name first.

Like this:
```
Bookmarks/
  Github home 
  python/
      Learn Python - Getting started tutorial
      advanced/
        Python Tricks - Pro tutorial
 ```
 
 I should be able to query by `tutorial` and receive both suggestions, as well as, query by `advanced tutorial` and receive only one (see the unit tests)

I'm not sure if this is align with the direction of the plugin, feel free to close the PR if it isn't

## Extra
 
 I also added some tests and a Makefile to run then with `make test`